### PR TITLE
Mismatched Prometheus Gauge Description

### DIFF
--- a/adapters/slack/slack.go
+++ b/adapters/slack/slack.go
@@ -37,7 +37,7 @@ import (
 var (
 	slackLatency = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "slack_latency_reports_millisecond",
-		Help: "Current temperature of the CPU.",
+		Help: "Latency of Slack in milliseconds.",
 	})
 	slackMessagesTx = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "slack_messages_sent_total",


### PR DESCRIPTION
Neat project, just noticed this running through.

slack_latency_reports_milliseconds Help info wasn't correct.
